### PR TITLE
Fixbug: ignoring 0 and the value equal to false

### DIFF
--- a/src/Form/NestedForm.php
+++ b/src/Form/NestedForm.php
@@ -339,7 +339,7 @@ class NestedForm
 
         $elementName = $elementClass = $errorKey = [];
 
-        $key = $this->key ?: 'new_'.static::DEFAULT_KEY_NAME;
+        $key = isset($this->key) ? $this->key : 'new_'.static::DEFAULT_KEY_NAME;
 
         if (is_array($column)) {
             foreach ($column as $k => $name) {


### PR DESCRIPTION
Key is null to use the default value, ignoring 0 and the value equal to false